### PR TITLE
Attempt to fix logrotate config

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,6 +86,8 @@
     path: "/etc/logrotate.d/openfortivpn"
     block: |
       /var/log/openfortivpn {
+        su root root
+        create 0644 root root
         rotate 7
         daily
         notifempty


### PR DESCRIPTION
Addresses the following error:
- `error: skipping "/var/log/openfortivpn" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.`